### PR TITLE
Update vss-extension.json

### DIFF
--- a/vss-extension.json
+++ b/vss-extension.json
@@ -94,7 +94,8 @@
             "targets": ["ms.vss-build-web.build-results-view"],
             "properties": {
                 "name": "Trivy",
-                "uri": "index.html"
+                "uri": "index.html",                
+                "supportsTasks": ["8f9cb13f-f551-439c-83e4-fac6801c3fab"]
             }
         }
     ],


### PR DESCRIPTION
adding "supportsTasks" property key to make the Trivy task visible in build result summary only when the task is actually being used. We are using Trivy task in few of our pipelines and the tab gives error [Timeline record(s) missing: cannot load results. Is Trivy configured to run on this build?] when trivy is task is not part of the pipeline.