### PR TITLE
hotfix(count reports functions): add optional chaining before forEach in counting reports

### DIFF
--- a/ui/src/BaseReport.tsx
+++ b/ui/src/BaseReport.tsx
@@ -46,8 +46,8 @@ export class BaseReport extends React.Component<BaseReportProps, BaseReportState
             return 0
         }
         let total = 0
-        assurance.Results.forEach(result => {
-            result.PolicyResults.forEach(policyResult => {
+        assurance.Results?.forEach(result => {
+            result.PolicyResults?.forEach(policyResult => {
                 if (Object.prototype.hasOwnProperty.call(policyResult, "Failed")) {
                     total++
                 }

--- a/ui/src/trivy.tsx
+++ b/ui/src/trivy.tsx
@@ -152,7 +152,7 @@ export function countReportIssues(report: Report): number {
 
 export function countAllReportsIssues(reports: Report[]): number {
     let total = 0
-    reports.forEach(function (report: Report) {
+    reports?.forEach(function (report: Report) {
         total += countReportIssues(report)
     })
     return total
@@ -160,21 +160,21 @@ export function countAllReportsIssues(reports: Report[]): number {
 
 export function countAllReportsVulnerabilities(reports: Report[]): number {
     let total = 0
-    reports.forEach(function (report: Report) {
+    reports?.forEach(function (report: Report) {
         total += countReportVulnerabilities(report)
     })
     return total
 }
 export function countAllReportsMisconfigurations(reports: Report[]): number {
     let total = 0
-    reports.forEach(function (report: Report) {
+    reports?.forEach(function (report: Report) {
         total += countReportMisconfigurations(report)
     })
     return total
 }
 export function countAllReportsSecrets(reports: Report[]): number {
     let total = 0
-    reports.forEach(function (report: Report) {
+    reports?.forEach(function (report: Report) {
         total += countReportSecrets(report)
     })
     return total
@@ -182,7 +182,7 @@ export function countAllReportsSecrets(reports: Report[]): number {
 
 export function countReportVulnerabilities(report: Report): number {
     let total = 0
-    report.Results.forEach(function (result: Result) {
+    report.Results?.forEach(function (result: Result) {
         if(Object.prototype.hasOwnProperty.call(result, 'Vulnerabilities') && result.Vulnerabilities !== null) {
             total += result.Vulnerabilities.length
         }
@@ -192,7 +192,7 @@ export function countReportVulnerabilities(report: Report): number {
 
 export function countReportMisconfigurations(report: Report): number {
     let total = 0
-    report.Results.forEach(function (result: Result) {
+    report.Results?.forEach(function (result: Result) {
         if(Object.prototype.hasOwnProperty.call(result, 'Misconfigurations') && result.Misconfigurations !== null) {
             total += result.Misconfigurations.length
         }
@@ -203,7 +203,7 @@ export function countReportMisconfigurations(report: Report): number {
 
 export function countReportSecrets(report: Report): number {
     let total = 0
-    report.Results.forEach(function (result: Result) {
+    report.Results?.forEach(function (result: Result) {
         if(Object.prototype.hasOwnProperty.call(result, 'Secrets') && result.Secrets !== null) {
             total += result.Secrets.length
         }


### PR DESCRIPTION
Hey, submitting this PR to resolve #8.
I have added `?.` (Optional chaining) before the `forEach` calls where the reports could be `undefined`.
This will prevent errors breaking the UI.
