### PR TITLE
Update latest Trivy version to v0.32.0

### DIFF
--- a/trivy-task/index.ts
+++ b/trivy-task/index.ts
@@ -4,7 +4,7 @@ import * as tool from 'azure-pipelines-tool-lib';
 import {ToolRunner} from 'azure-pipelines-task-lib/toolrunner';
 import task = require('azure-pipelines-task-lib/task');
 
-const latestTrivyVersion = "v0.29.2"
+const latestTrivyVersion = "v0.32.0"
 const tmpPath = "/tmp/"
 
 async function run() {


### PR DESCRIPTION
Hi, Trivy has updated there CLI. The latest version is now 0.32.0.