### PR TITLE
#22 Support for docker login DockerConfig

### DIFF
--- a/marketplace.md
+++ b/marketplace.md
@@ -26,7 +26,7 @@ You can supply several inputs to customise the task.
 | `debug`      | Enable debug logging in the build output.                                                                                            |
 | `path`       | The path to scan relative to the root of the repository being scanned, if an `fs` scan is required. Cannot be set if `image` is set. |
 | `severities` | The severities (`CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN`) to include in the scan (comma sperated). Defaults to `CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN`. |
-| `ignoreUnfixed` | When set to `true` all unfixed vulnerabilities will be skipped. Default to `false`.                                               |
+| `ignoreUnfixed` | When set to `true` all unfixed vulnerabilities will be skipped. Defaults to `false`.                                               |
 | `image`      | The image to scan if an `image` scan is required. Cannot be set if `path` is set.                                                    |
 | `exitCode`   | The exit-code to use when Trivy detects issues. Set to `0` to prevent the build failing when Trivy finds issues. Defaults to `1`.    |
 | `aquaKey`    | The Aqua API Key to use to link scan results to your Aqua Security account _(not required)_.                                         |

--- a/marketplace.md
+++ b/marketplace.md
@@ -22,8 +22,11 @@ You can supply several inputs to customise the task.
 |--------------|--------------------------------------------------------------------------------------------------------------------------------------|
 | `version`    | The version of Trivy to use. Currently defaults to `latest`.                                                                         |
 | `docker`     | Run Trivy using the aquasec/trivy docker image. Alternatively the Trivy binary will be run natively. Defaults to `true`.             |
+| `loginDockerConfig` | Set this to true if the `Docker login` task is used to access private repositories. Defaults to `false`.                      |
 | `debug`      | Enable debug logging in the build output.                                                                                            |
 | `path`       | The path to scan relative to the root of the repository being scanned, if an `fs` scan is required. Cannot be set if `image` is set. |
+| `severities` | The severities (`CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN`) to include in the scan (comma sperated). Defaults to `CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN`. |
+| `ignoreUnfixed` | When set to `true` all unfixed vulnerabilities will be skipped. Default to `false`.                                               |
 | `image`      | The image to scan if an `image` scan is required. Cannot be set if `path` is set.                                                    |
 | `exitCode`   | The exit-code to use when Trivy detects issues. Set to `0` to prevent the build failing when Trivy finds issues. Defaults to `1`.    |
 | `aquaKey`    | The Aqua API Key to use to link scan results to your Aqua Security account _(not required)_.                                         |

--- a/trivy-task/index.ts
+++ b/trivy-task/index.ts
@@ -17,7 +17,7 @@ async function run() {
     let image = task.getInput("image", false)
     let loginDockerConfig = task.getBoolInput("loginDockerConfig", false)
     let ignoreUnfixed = task.getBoolInput("ignoreUnfixed", false)
-    let serverities = task.getInput("serverities", false) ?? 'CRITICAL,HIGH,MEDIUM,LOW'
+    let severities = task.getInput("severities", false) ?? 'CRITICAL,HIGH,MEDIUM,LOW'
 
     if (scanPath === undefined && image === undefined) {
         throw new Error("You must specify something to scan. Use either the 'image' or 'path' option.")
@@ -47,9 +47,9 @@ async function run() {
     }
 
     if (scanPath !== undefined) {
-        configureScan(runner, "fs", scanPath, outputPath, serverities, ignoreUnfixed)
+        configureScan(runner, "fs", scanPath, outputPath, severities, ignoreUnfixed)
     } else if (image !== undefined) {
-        configureScan(runner, "image", image, outputPath, serverities, ignoreUnfixed)
+        configureScan(runner, "image", image, outputPath, severities, ignoreUnfixed)
     }
 
     console.log("Running Trivy...")
@@ -131,7 +131,7 @@ async function createRunner(docker: boolean, loginDockerConfig: boolean): Promis
     return runner
 }
 
-function configureScan(runner: ToolRunner, type: string, target: string, outputPath: string, serverities: string, ignoreUnfixed: boolean) {
+function configureScan(runner: ToolRunner, type: string, target: string, outputPath: string, severities: string, ignoreUnfixed: boolean) {
     console.log("Configuring options for image scan...")
     let exitCode = task.getInput("exitCode", false)
     if (exitCode === undefined) {
@@ -142,7 +142,7 @@ function configureScan(runner: ToolRunner, type: string, target: string, outputP
     runner.arg(["--format", "json"]);
     runner.arg(["--output", outputPath]);
     runner.arg(["--security-checks", "vuln,config,secret"])
-    runner.arg(["--severity", serverities]);
+    runner.arg(["--severity", severities]);
     if (ignoreUnfixed) {
         runner.arg(["--ignore-unfixed"]);
     }

--- a/trivy-task/index.ts
+++ b/trivy-task/index.ts
@@ -17,7 +17,7 @@ async function run() {
     let image = task.getInput("image", false)
     let loginDockerConfig = task.getBoolInput("loginDockerConfig", false)
     let ignoreUnfixed = task.getBoolInput("ignoreUnfixed", false)
-    let severities = task.getInput("severities", false) ?? 'CRITICAL,HIGH,MEDIUM,LOW'
+    let severities = task.getInput("severities", false)
 
     if (scanPath === undefined && image === undefined) {
         throw new Error("You must specify something to scan. Use either the 'image' or 'path' option.")

--- a/trivy-task/index.ts
+++ b/trivy-task/index.ts
@@ -15,6 +15,7 @@ async function run() {
 
     let scanPath = task.getInput("path", false)
     let image = task.getInput("image", false)
+    let loginDockerConfig = task.getBoolInput("loginDockerConfig", false)
 
     if (scanPath === undefined && image === undefined) {
         throw new Error("You must specify something to scan. Use either the 'image' or 'path' option.")
@@ -37,7 +38,7 @@ async function run() {
         process.env.AQUA_ASSURANCE_EXPORT = assurancePath
     }
 
-    const runner = await createRunner(task.getBoolInput("docker", false));
+    const runner = await createRunner(task.getBoolInput("docker", false), loginDockerConfig);
 
     if (task.getBoolInput("debug", false)) {
         runner.arg("--debug")
@@ -90,7 +91,7 @@ function getAquaAccount(): aquaCredentials {
     }
 }
 
-async function createRunner(docker: boolean): Promise<ToolRunner> {
+async function createRunner(docker: boolean, loginDockerConfig: boolean): Promise<ToolRunner> {
     const version: string | undefined = task.getInput('version', true);
     if (version === undefined) {
         throw new Error("version is not defined")
@@ -108,7 +109,7 @@ async function createRunner(docker: boolean): Promise<ToolRunner> {
     const cwd = process.cwd()
 
     runner.line("run --rm")
-    runner.line("-v " + home + "/.docker:/root/.docker")
+    loginDockerConfig ? runner.line("-v " + task.getVariable("DOCKER_CONFIG") + ":/root/.docker") :  runner.line("-v " + home + "/.docker:/root/.docker")
     runner.line("-v /tmp:/tmp")
     runner.line("-v " + cwd + ":/src")
     runner.line("--workdir /src")

--- a/trivy-task/index.ts
+++ b/trivy-task/index.ts
@@ -17,7 +17,7 @@ async function run() {
     let image = task.getInput("image", false)
     let loginDockerConfig = task.getBoolInput("loginDockerConfig", false)
     let ignoreUnfixed = task.getBoolInput("ignoreUnfixed", false)
-    let severities = task.getInput("severities", false)
+    let severities = task.getInput("severities", false) ?? ""
 
     if (scanPath === undefined && image === undefined) {
         throw new Error("You must specify something to scan. Use either the 'image' or 'path' option.")

--- a/trivy-task/index.ts
+++ b/trivy-task/index.ts
@@ -142,7 +142,9 @@ function configureScan(runner: ToolRunner, type: string, target: string, outputP
     runner.arg(["--format", "json"]);
     runner.arg(["--output", outputPath]);
     runner.arg(["--security-checks", "vuln,config,secret"])
-    runner.arg(["--severity", severities]);
+    if (severities.length) {
+        runner.arg(["--severity", severities]);
+    }
     if (ignoreUnfixed) {
         runner.arg(["--ignore-unfixed"]);
     }

--- a/trivy-task/task.json
+++ b/trivy-task/task.json
@@ -59,10 +59,10 @@
             "helpMarkDown": "The specified image will be scanned using an 'image' scan type. If this option is used, the 'path' option cannot be set."
         },
         {
-            "name": "serverities",
+            "name": "severities",
             "type": "string",
-            "label": "The serverities to include in the scan (comma sperated)",
-            "defaultValue": "",
+            "label": "The severities (CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN) to include in the scan (comma sperated)",
+            "defaultValue": "CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN",
             "required": false,
             "helpMarkDown": "The specified path or image will be scanned for the provided serverities."
         },

--- a/trivy-task/task.json
+++ b/trivy-task/task.json
@@ -43,6 +43,14 @@
             "helpMarkDown": "The specified path will be scanned using an 'fs' scan type. If this option is used, the 'image' option cannot be set."
         },
         {
+            "name": "loginDockerConfig",
+            "type": "boolean",
+            "label": "Use Docker login task DockerConfig",
+            "defaultValue": "false",
+            "required": false,
+            "helpMarkDown": "Use DOCKER_CONFIG ENV as DockerConfig (set by Docker login task)."
+        },
+        {
             "name": "image",
             "type": "string",
             "label": "The image to scan",

--- a/trivy-task/task.json
+++ b/trivy-task/task.json
@@ -59,6 +59,22 @@
             "helpMarkDown": "The specified image will be scanned using an 'image' scan type. If this option is used, the 'path' option cannot be set."
         },
         {
+            "name": "serverities",
+            "type": "string",
+            "label": "The serverities to include in the scan (comma sperated)",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "The specified path or image will be scanned for the provided serverities."
+        },
+        {
+            "name": "ignoreUnfixed",
+            "type": "boolean",
+            "label": "Ignore unpatched/unfixed vulnerabilities",
+            "defaultValue": false,
+            "required": false,
+            "helpMarkDown": "This means you can't fix these vulnerabilities even if you update all packages."
+        },
+        {
             "name": "exitCode",
             "type": "string",
             "label": "Exit code when Trivy detects issues.",


### PR DESCRIPTION
In this version I added a task variable `loginDockerConfig`. If you set this to true the DockerConfig directory set by the `Docker` task `login` is used. This is necessary for private repositories who require authentication. See #22 where this is described.