### PR TITLE
change runner argument to '--scanners'

### DIFF
--- a/trivy-task/index.ts
+++ b/trivy-task/index.ts
@@ -142,7 +142,7 @@ function configureScan(runner: ToolRunner, type: string, target: string, outputP
     runner.arg(["--exit-code", exitCode]);
     runner.arg(["--format", "json"]);
     runner.arg(["--output", outputPath]);
-    runner.arg(["--security-checks", "vuln,config,secret"])
+    runner.arg(["--scanners", "vuln,config,secret"])
     if (severities.length) {
         runner.arg(["--severity", severities]);
     }


### PR DESCRIPTION
This pull request addresses the deprecated warning '--security-checks' that was being logged by the runner. The concern was also documented in issue #36.