### PR TITLE
Only add scanners when there are no options

### DIFF
--- a/trivy-task/index.ts
+++ b/trivy-task/index.ts
@@ -142,7 +142,6 @@ function configureScan(runner: ToolRunner, type: string, target: string, outputP
     runner.arg(["--exit-code", exitCode]);
     runner.arg(["--format", "json"]);
     runner.arg(["--output", outputPath]);
-    runner.arg(["--security-checks", "vuln,config,secret"])
     if (severities.length) {
         runner.arg(["--severity", severities]);
     }
@@ -151,6 +150,8 @@ function configureScan(runner: ToolRunner, type: string, target: string, outputP
     }
     if (options.length) {
         runner.line(options)
+    } else {
+        runner.arg(["--scanner", "vuln,misconfig,secret"])
     }
 
     runner.arg(target)


### PR DESCRIPTION
The default scanner list is now deprecated and also does not allow for disabling the secret scanner.

Similar to:
- https://github.com/aquasecurity/trivy-azure-pipelines-task/pull/47/
Related to:
- https://github.com/aquasecurity/trivy-azure-pipelines-task/issues/41
- https://github.com/aquasecurity/trivy-azure-pipelines-task/issues/36