### PR TITLE
Use correct Trivy argument for scanners when options are not provided

### DIFF
--- a/trivy-task/index.ts
+++ b/trivy-task/index.ts
@@ -152,7 +152,7 @@ function configureScan(runner: ToolRunner, type: string, target: string, outputP
     if (options.length) {
         runner.line(options)
     } else {
-        runner.arg(["--scanner", "vuln,misconfig,secret"])
+        runner.arg(["--scanners", "vuln,misconfig,secret"])
     }
 
     runner.arg(target)


### PR DESCRIPTION
The newest release of ADO Trivy task (1.5.0) that was released two weeks ago includes a bug where an incorrect argument is being sent to Trivy if no options are explicitly provided. The task will then fail with: ` FATAL	Fatal error	unknown flag: --scanner`
The workaround currently is to explicitly define options in the pipeline task like `options: "--scanners vuln,config,secret"`

The correct argument is `--scanners` - this PR fixes the issue.