### PR TITLE
Use system package

### DIFF
--- a/trivy-task/task.json
+++ b/trivy-task/task.json
@@ -113,6 +113,14 @@
             "defaultValue": "",
             "required": false,
             "helpMarkDown": "Additional flags to pass to Trivy command line."
+        },
+        {
+            "name": "useSystemInstallation",
+            "type": "boolean",
+            "label": "Run Trivy using from the system PATH.",
+            "defaultValue": "false",
+            "required": false,
+            "helpMarkDown": "Use Trivy executable pre-installed as system package. If this option is used, the 'version' option is ignored."
         }
     ],
     "execution": {


### PR DESCRIPTION
## Description
My organization requires us to lock the utilities on our build applications to specific versions, and not install utilities through DevOps pipeline tasks. We would like to use the Trivy Azure DevOps Pipelines Task for its UI functionality, but the lack of option to use the package on the system prevents us from doing so.

This PR adds an 'useSystemInstallation' input, that runs the Trivy tool from the system PATH instead of installing Trivy as a temporary tool. 