### PR TITLE
Added fixed version column in vulnerabilities table

### DIFF
--- a/ui/src/VulnerabilitiesTable.tsx
+++ b/ui/src/VulnerabilitiesTable.tsx
@@ -25,6 +25,7 @@ interface ListVulnerability extends ISimpleTableCell {
     PkgName: ISimpleListCell
     Title: ISimpleListCell
     FixAvailable: ISimpleListCell
+    FixedVersion: ISimpleListCell
 }
 
 function renderVulnerabilitySeverity(rowIndex: number, columnIndex: number, tableColumn: ITableColumn<ListVulnerability>, tableItem: ListVulnerability): JSX.Element {
@@ -84,6 +85,18 @@ const fixedColumns = [
         columnLayout: TableColumnLayout.singleLine,
         id: "FixAvailable",
         name: "Fix Available",
+        readonly: true,
+        renderCell: renderSimpleCell,
+        width: new ObservableValue(-5),
+        sortProps: {
+            ariaLabelAscending: "Sorted A to Z",
+            ariaLabelDescending: "Sorted Z to A",
+        },
+    },
+    {
+        columnLayout: TableColumnLayout.singleLine,
+        id: "FixedVersion",
+        name: "Fixed Version",
         readonly: true,
         renderCell: renderSimpleCell,
         width: new ObservableValue(-5),
@@ -203,7 +216,7 @@ function convertVulnerabilities(results: Result[]): ListVulnerability[] {
                     PkgName: {text: vulnerability.PkgName},
                     Title: {text: vulnerability.Title},
                     FixAvailable: {text: vulnerability.FixedVersion ? "Yes" : "No"},
-
+                    FixedVersion: {text: vulnerability.FixedVersion ?? "N/A"},
                 })
             })
         }


### PR DESCRIPTION
Hello,
My organization has some new requirements where we need to provide a report with the fixed version of identified vulnerabilities. The information is currently not present in the tab report on Azure DevOps, and thus I have added it in this pull request.
I understand this needs to be handled properly in order to not lead to confusion for cases where a fixed version is not available, so take my changes as only a suggestion on which you can feel free to update with content that you may find more relevant.