### PR TITLE
Get Latest Version of Trivy From GitHub

### DIFF
--- a/trivy-task/index.ts
+++ b/trivy-task/index.ts
@@ -5,7 +5,7 @@ import {ToolRunner} from 'azure-pipelines-task-lib/toolrunner';
 import task = require('azure-pipelines-task-lib/task');
 import { homedir } from 'os';
 
-const latestTrivyVersion = "v0.59.1"
+const fallbackTrivyVersion = "v0.59.1"
 const tmpPath = "/tmp/"
 
 async function run() {
@@ -197,9 +197,37 @@ function stripV(version: string): string {
 }
 
 async function getArtifactURL(version: string): Promise<string> {
-    if(version === "latest") {
+    if (version === "latest") {
+      let latestTrivyVersion = "";
+
+      try {
+        latestTrivyVersion = await fetch(
+          new Request("https://api.github.com/repos/aquasecurity/trivy/releases/latest")
+        ).then(response => {
+          if (response.status === 200) {
+            return response.json().then(data => {
+              return data.name;
+            });
+          }
+          else {
+            throw new Error("Unable to Retrieve Latest Version information from GitHub")
+          }
+        });
+      } catch {
+        console.log(
+          "Unable to Retrieve Latest Version information from GitHub, falling back to " +
+            fallbackTrivyVersion
+        );
+      }
+            
+      if (latestTrivyVersion) {
         version = latestTrivyVersion
+      }
+      else {
+        version = fallbackTrivyVersion
+      }
     }
+
     console.log("Required Trivy version is " + version)
     let arch = ""
     switch (os.arch()) {

--- a/trivy-task/index.ts
+++ b/trivy-task/index.ts
@@ -198,16 +198,17 @@ function stripV(version: string): string {
 
 async function getArtifactURL(version: string): Promise<string> {
     if (version === "latest") {
-      let latestTrivyVersion = "";
-
+        let latestTrivyVersion: string | undefined;
       try {
         latestTrivyVersion = await fetch(
-          new Request("https://api.github.com/repos/aquasecurity/trivy/releases/latest")
+          new Request("https://github.com/aquasecurity/trivy/releases/latest")
         ).then(response => {
-          if (response.status === 200) {
-            return response.json().then(data => {
-              return data.name;
-            });
+          if (response.headers.has("location")) {
+            const location = response.headers.get("location");
+            const parts = location?.split("/");
+            if (parts) {
+              return parts[parts.length - 1];
+            }
           }
           else {
             throw new Error("Unable to Retrieve Latest Version information from GitHub")
@@ -215,12 +216,12 @@ async function getArtifactURL(version: string): Promise<string> {
         });
       } catch {
         console.log(
-          "Unable to Retrieve Latest Version information from GitHub, falling back to " +
-            fallbackTrivyVersion
+          `Unable to Retrieve Latest Version information from GitHub, falling back to ${fallbackTrivyVersion}`
         );
       }
             
       if (latestTrivyVersion) {
+        console.log(`Latest Trivy version is ${latestTrivyVersion}`);
         version = latestTrivyVersion
       }
       else {


### PR DESCRIPTION
This is a simple enhancement that queries the GitHub releases for the latest version of Trivy, and falls back to the hardcoded _latest_ version if that request fails. 