### PR TITLE
fix: use the tools folder for the binary

### DIFF
--- a/trivy-task/index.ts
+++ b/trivy-task/index.ts
@@ -108,7 +108,9 @@ async function run() {
   if (task.exist(outputPath)) {
     generateAdditionalReports(outputPath);
   } else {
-    task.error('Trivy seems to have failed so no output path to generate reports from.');
+    task.error(
+      'Trivy seems to have failed so no output path to generate reports from.'
+    );
   }
   console.log('Done!');
 }

--- a/trivy-task/task.json
+++ b/trivy-task/task.json
@@ -8,7 +8,7 @@
   "helpUrl": "https://github.com/aquasecurity/trivy-azure-pipelines-task",
   "category": "Test",
   "author": "Aqua Security",
-  "version": { "Major":1,"Minor":11,"Patch":28 },
+  "version": { "Major":1,"Minor":11,"Patch":32 },
   "instanceNameFormat": "Echo trivy $(version)",
   
   "groups": [
@@ -286,6 +286,9 @@
   ],
   "execution": {
     "Node20_1": {
+      "target": "index.js"
+    },
+    "Node10": {
       "target": "index.js"
     }
   }

--- a/trivy-task/trivyLoader.ts
+++ b/trivy-task/trivyLoader.ts
@@ -9,7 +9,8 @@ import { homedir } from 'os';
 
 const fallbackTrivyVersion = 'v0.59.1';
 let trivyPath: string | undefined = undefined;
-export const tmpPath = '/tmp/';
+export const tmpPath = task.getVariable('Agent.TempDirectory') + '/';
+const toolsDirectory = task.getVariable('Agent.ToolsDirectory') + '/';
 
 export async function createRunner(): Promise<ToolRunner> {
   const docker = task.getBoolInput('docker', false);
@@ -26,6 +27,8 @@ export async function createRunner(): Promise<ToolRunner> {
   if (!docker) {
     if (!useSystemInstallation) {
       console.log('Run requested using local Trivy binary...');
+      // ensure that the path is created
+      task.mkdirP(tmpPath);
       if (!trivyPath) {
         trivyPath = await installTrivy(version);
       }
@@ -87,7 +90,7 @@ async function installTrivy(version: string): Promise<string> {
     version = await getLatestTrivyVersion();
   }
   const bin = `trivy_${stripV(version).replaceAll('.', '_')}`;
-  const binPath = tmpPath + bin;
+  const binPath = toolsDirectory + bin;
 
   if (task.exist(binPath)) {
     console.log('Trivy already installed, skipping installation');

--- a/vss-extension.dev.json
+++ b/vss-extension.dev.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "trivy-official-dev",
   "publisher": "AquaSecurityOfficial",
-  "version": "1.11.28",
+  "version": "1.11.32",
   "name": "trivy-dev",
   "description": "Trivy is the world’s most popular open source vulnerability and misconfiguration scanner. It is reliable, fast, extremely easy to use, and it works wherever you need it.",
   "repository": {

--- a/vss-extension.json.tmpl
+++ b/vss-extension.json.tmpl
@@ -25,7 +25,7 @@
         "scanner"
     ],
     "icons": {
-        "default": "images/extension-icon.png"
+        "default": "icon.png"
     },
     "files": [
         {


### PR DESCRIPTION
When downloading the different versions of Trivy, use the agent tools
folder to write to. Also, use the agent temp directory to create the
output files.

Resolves #44
