### PR TITLE
Added mount for Trivy cache

### DIFF
--- a/trivy-task/trivyLoader.ts
+++ b/trivy-task/trivyLoader.ts
@@ -59,6 +59,7 @@ export async function createRunner(): Promise<ToolRunner> {
     ? runner.line('-v ' + `${task.getVariable('DOCKER_CONFIG')}:/root/.docker`)
     : runner.line('-v ' + `${dockerHome}:/root/.docker`);
   runner.line(`-v ${tmpPath}:/tmp`);
+  runner.line(`-v ${tmpPath}.cache:/root/.cache/trivy`);
   runner.line('-v /var/run/docker.sock:/var/run/docker.sock');
   runner.line(`-v ${cwd}:/src`);
   runner.line('--workdir /src');


### PR DESCRIPTION
Preserve Trivy cache to reduce DB downloads on each re-run on same agent.