### PR TITLE
fix: don't split the options line

### DIFF
--- a/trivy-task/index.ts
+++ b/trivy-task/index.ts
@@ -159,9 +159,6 @@ function configureScan(
   if (ignoreUnfixed) {
     runner.arg(['--ignore-unfixed']);
   }
-  if (options.length) {
-    runner.arg(options.split(' '));
-  }
 
   // if scanners haven't been set in the options, add them here
   if (
@@ -169,6 +166,10 @@ function configureScan(
     !options.includes('--security-checks')
   ) {
     runner.arg(['--scanners', scanners]);
+  }
+
+  if (options.length) {
+    runner.line(options);
   }
 
   runner.arg(target);

--- a/trivy-task/task.json
+++ b/trivy-task/task.json
@@ -8,7 +8,7 @@
   "helpUrl": "https://github.com/aquasecurity/trivy-azure-pipelines-task",
   "category": "Test",
   "author": "Aqua Security",
-  "version": { "Major":1,"Minor":11,"Patch":81 },
+  "version": { "Major":1,"Minor":11,"Patch":85 },
   "instanceNameFormat": "Echo trivy $(version)",
   
   "groups": [
@@ -187,7 +187,10 @@
       "defaultValue": "",
       "required": false,
       "helpMarkDown": "The Aqua API Key is used to upload scan results to your Aqua Security account.",
-      "groupName": "commercial"
+      "groupName": "commercial",
+      "properties": {
+        "isSecret": true
+      }
     },
     {
       "name": "aquaSecret",
@@ -196,7 +199,10 @@
       "defaultValue": "",
       "required": false,
       "helpMarkDown": "The Aqua API Secret is used to upload scan results to your Aqua Security account.",
-      "groupName": "commercial"
+      "groupName": "commercial",
+      "properties": {
+        "isSecret": true
+      }
     },
     {
       "name": "cosignOutput",

--- a/trivy-task/task.json.tmpl
+++ b/trivy-task/task.json.tmpl
@@ -187,7 +187,10 @@
       "defaultValue": "",
       "required": false,
       "helpMarkDown": "The Aqua API Key is used to upload scan results to your Aqua Security account.",
-      "groupName": "commercial"
+      "groupName": "commercial",
+      "properties": {
+        "isSecret": true
+      }
     },
     {
       "name": "aquaSecret",
@@ -196,7 +199,10 @@
       "defaultValue": "",
       "required": false,
       "helpMarkDown": "The Aqua API Secret is used to upload scan results to your Aqua Security account.",
-      "groupName": "commercial"
+      "groupName": "commercial",
+      "properties": {
+        "isSecret": true
+      }
     },
     {
       "name": "cosignOutput",

--- a/vss-extension.dev.json
+++ b/vss-extension.dev.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "trivy-official-dev",
   "publisher": "AquaSecurityOfficial",
-  "version": "1.11.81",
+  "version": "1.11.85",
   "name": "trivy-dev",
   "description": "Trivy is the world’s most popular open source vulnerability and misconfiguration scanner. It is reliable, fast, extremely easy to use, and it works wherever you need it.",
   "repository": {


### PR DESCRIPTION
there is a regression where the options is being split where as itshould be treated as a line verbatim. This reverts that issue and resolves #115 
