### PR TITLE
fix: Fix the switching of tabs when there are no results

### DIFF
--- a/ui/src/AssuranceTable.tsx
+++ b/ui/src/AssuranceTable.tsx
@@ -12,14 +12,14 @@ import {
   Table,
   TableColumnLayout,
 } from 'azure-devops-ui/Table';
-import { AssuranceResult, PolicyResult } from './trivy';
+import { AssuranceReport, AssuranceResult, PolicyResult } from './trivy';
 import { ISimpleListCell } from 'azure-devops-ui/List';
 import { ZeroData } from 'azure-devops-ui/ZeroData';
 import { compareSeverity } from './severity';
 import { ArrayItemProvider } from 'azure-devops-ui/Utilities/Provider';
 
 interface AssuranceTableProps {
-  results: AssuranceResult[];
+  report?: AssuranceReport;
 }
 
 interface ListAssurance extends ISimpleTableCell {
@@ -102,7 +102,7 @@ export class AssuranceTable extends React.Component<AssuranceTableProps> {
   constructor(props: AssuranceTableProps) {
     super(props);
     this.results = new ObservableArray<ListAssurance>(
-      convertAssuranceIssues(props.results)
+      convertAssuranceIssues(props.report?.Results || [])
     );
     // sort by severity desc by default
     this.results.splice(

--- a/ui/src/BaseReport.tsx
+++ b/ui/src/BaseReport.tsx
@@ -66,6 +66,11 @@ export class BaseReport extends React.Component<
     const licensesCount = countReportLicenses(this.props.report);
     const assuranceCount = this.countAssuranceIssues(this.props.assurance);
 
+    const hasReportResults =
+      this.props.report &&
+      this.props.report.Results &&
+      this.props.report.Results.length > 0;
+
     return (
       <div className="flex-grow">
         <div className="flex-grow">
@@ -117,29 +122,30 @@ export class BaseReport extends React.Component<
           </TabBar>
         </div>
         <div className="tab-content flex-row">
-          {this.state.selectedTabId === 'vulnerabilities' && (
-            <div className="flex-grow">
-              <VulnerabilitiesTable results={this.props.report.Results} />
-            </div>
-          )}
+          {this.state.selectedTabId === 'vulnerabilities' &&
+            hasReportResults && (
+              <div className="flex-grow">
+                <VulnerabilitiesTable report={this.props.report} />
+              </div>
+            )}
           {this.state.selectedTabId === 'misconfigurations' && (
             <div className="flex-grow">
-              <MisconfigurationsTable results={this.props.report.Results} />
+              <MisconfigurationsTable report={this.props.report} />
             </div>
           )}
           {this.state.selectedTabId === 'secrets' && (
             <div className="flex-grow">
-              <SecretsTable results={this.props.report.Results} />
+              <SecretsTable report={this.props.report} />
             </div>
           )}
           {this.state.selectedTabId === 'licenses' && (
             <div className="flex-grow">
-              <LicensesTable results={this.props.report.Results} />
+              <LicensesTable report={this.props.report} />
             </div>
           )}
           {this.state.selectedTabId === 'assurance' && (
             <div className="flex-grow">
-              <AssuranceTable results={this.props.assurance?.Results || []} />
+              <AssuranceTable report={this.props.assurance} />
             </div>
           )}
         </div>

--- a/ui/src/LicenseTable.tsx
+++ b/ui/src/LicenseTable.tsx
@@ -12,7 +12,7 @@ import {
   Table,
   TableColumnLayout,
 } from 'azure-devops-ui/Table';
-import { Result, License, Severity } from './trivy';
+import { Report, Result, License, Severity } from './trivy';
 import { ISimpleListCell } from 'azure-devops-ui/List';
 import { ZeroData } from 'azure-devops-ui/ZeroData';
 import { compareSeverity, renderSeverity } from './severity';
@@ -20,7 +20,7 @@ import { ITableColumn } from 'azure-devops-ui/Components/Table/Table.Props';
 import { ArrayItemProvider } from 'azure-devops-ui/Utilities/Provider';
 
 interface LicenseTableProps {
-  results: Result[];
+  report: Report;
 }
 
 interface ListLicense extends ISimpleTableCell {
@@ -150,7 +150,7 @@ export class LicensesTable extends React.Component<LicenseTableProps> {
   constructor(props: LicenseTableProps) {
     super(props);
     this.results = new ObservableArray<ListLicense>(
-      convertLicenses(props.results)
+      convertLicenses(props.report.Results || [])
     );
     // sort by severity desc by default
     this.results.splice(

--- a/ui/src/MisconfigurationsTable.tsx
+++ b/ui/src/MisconfigurationsTable.tsx
@@ -13,7 +13,7 @@ import {
   Table,
   TableColumnLayout,
 } from 'azure-devops-ui/Table';
-import { Misconfiguration, Result, Severity } from './trivy';
+import { Report, Misconfiguration, Result, Severity } from './trivy';
 import { ISimpleListCell } from 'azure-devops-ui/List';
 import { ZeroData } from 'azure-devops-ui/ZeroData';
 import { compareSeverity, renderSeverity } from './severity';
@@ -21,7 +21,7 @@ import { ITableColumn } from 'azure-devops-ui/Components/Table/Table.Props';
 import { ArrayItemProvider } from 'azure-devops-ui/Utilities/Provider';
 
 interface MisconfigurationsTableProps {
-  results: Result[];
+  report: Report;
 }
 
 interface ListMisconfiguration extends ISimpleTableCell {
@@ -139,7 +139,7 @@ export class MisconfigurationsTable extends React.Component<MisconfigurationsTab
   constructor(props: MisconfigurationsTableProps) {
     super(props);
     this.results = new ObservableArray<ListMisconfiguration>(
-      convertMisconfigurations(props.results)
+      convertMisconfigurations(props.report.Results || [])
     );
     // sort by severity desc by default
     this.results.splice(

--- a/ui/src/SecretsTable.tsx
+++ b/ui/src/SecretsTable.tsx
@@ -13,7 +13,7 @@ import {
   Table,
   TableColumnLayout,
 } from 'azure-devops-ui/Table';
-import { Result, Secret, Severity } from './trivy';
+import { Report, Result, Secret, Severity } from './trivy';
 import { ISimpleListCell } from 'azure-devops-ui/List';
 import { ZeroData } from 'azure-devops-ui/ZeroData';
 import { compareSeverity, renderSeverity } from './severity';
@@ -21,7 +21,7 @@ import { ITableColumn } from 'azure-devops-ui/Components/Table/Table.Props';
 import { ArrayItemProvider } from 'azure-devops-ui/Utilities/Provider';
 
 interface SecretsTableProps {
-  results: Result[];
+  report: Report;
 }
 
 interface ListSecret extends ISimpleTableCell {
@@ -167,7 +167,7 @@ export class SecretsTable extends React.Component<SecretsTableProps> {
   constructor(props: SecretsTableProps) {
     super(props);
     this.results = new ObservableArray<ListSecret>(
-      convertSecrets(props.results)
+      convertSecrets(props.report.Results || [])
     );
     // sort by severity desc by default
     this.results.splice(

--- a/ui/src/VulnerabilitiesTable.tsx
+++ b/ui/src/VulnerabilitiesTable.tsx
@@ -12,7 +12,7 @@ import {
   Table,
   TableColumnLayout,
 } from 'azure-devops-ui/Table';
-import { Result, Severity, Vulnerability } from './trivy';
+import { Report, Result, Severity, Vulnerability } from './trivy';
 import { ISimpleListCell } from 'azure-devops-ui/List';
 import { ZeroData } from 'azure-devops-ui/ZeroData';
 import { compareSeverity, renderSeverity } from './severity';
@@ -20,7 +20,7 @@ import { ITableColumn } from 'azure-devops-ui/Components/Table/Table.Props';
 import { ArrayItemProvider } from 'azure-devops-ui/Utilities/Provider';
 
 interface VulnerabilitiesTableProps {
-  results: Result[];
+  report: Report;
 }
 
 interface ListVulnerability extends ISimpleTableCell {
@@ -152,7 +152,7 @@ export class VulnerabilitiesTable extends React.Component<VulnerabilitiesTablePr
   constructor(props: VulnerabilitiesTableProps) {
     super(props);
     this.results = new ObservableArray<ListVulnerability>(
-      convertVulnerabilities(props.results)
+      convertVulnerabilities(props.report.Results || [])
     );
     // sort by severity desc by default
     this.results.splice(

--- a/ui/src/trivy.tsx
+++ b/ui/src/trivy.tsx
@@ -218,6 +218,10 @@ export function countAllReportLicenses(reports: Report[]): number {
 export function countReportVulnerabilities(report: Report): number {
   let total = 0;
   report.Results?.forEach(function (result: Result) {
+    if (!result) {
+      return;
+    }
+
     if (
       Object.prototype.hasOwnProperty.call(result, 'Vulnerabilities') &&
       result.Vulnerabilities !== null
@@ -231,6 +235,9 @@ export function countReportVulnerabilities(report: Report): number {
 export function countReportMisconfigurations(report: Report): number {
   let total = 0;
   report.Results?.forEach(function (result: Result) {
+    if (!result) {
+      return;
+    }
     if (
       Object.prototype.hasOwnProperty.call(result, 'Misconfigurations') &&
       result.Misconfigurations !== null
@@ -244,6 +251,9 @@ export function countReportMisconfigurations(report: Report): number {
 export function countReportSecrets(report: Report): number {
   let total = 0;
   report.Results?.forEach(function (result: Result) {
+    if (!result) {
+      return;
+    }
     if (
       Object.prototype.hasOwnProperty.call(result, 'Secrets') &&
       result.Secrets !== null
@@ -257,6 +267,9 @@ export function countReportSecrets(report: Report): number {
 export function countReportLicenses(report: Report): number {
   let total = 0;
   report.Results?.forEach(function (result: Result) {
+    if (!result) {
+      return;
+    }
     if (
       Object.prototype.hasOwnProperty.call(result, 'Licenses') &&
       result.Licenses !== null


### PR DESCRIPTION
When the reports are switched between, if the originating report doesn't
have any results the state seems to become stagnent and changing the
drop down doesn't change the tables.

This forces that by using an additional hasReportResults to trigger a
redraw of the VulnerabilitiesTable.

Also switched the tables to take a report rather than a results slice

Resolves #117 
