### PR TITLE
fix: only explicitly set scanners when specified

### DIFF
--- a/trivy-task/index.ts
+++ b/trivy-task/index.ts
@@ -22,16 +22,18 @@ async function run() {
 
   // check scanners only has valid values
   const validScanners = ['vuln', 'misconfig', 'secret', 'license'];
-  const scannerList = scanners.split(',');
-  scannerList.forEach((scanner) => {
-    if (!validScanners.includes(scanner.trim())) {
-      throw new Error(
-        `Invalid scanner value '${scanner}' in 'scanners'. Valid values are: ${validScanners.join(
-          ', '
-        )}`
-      );
-    }
-  });
+
+  if (scanners !== '') {
+    scanners.split(',').forEach((scanner) => {
+      if (!validScanners.includes(scanner.trim())) {
+        throw new Error(
+          `Invalid scanner value '${scanner}' in 'scanners'. Valid values are: ${validScanners.join(
+            ', '
+          )}`
+        );
+      }
+    });
+  }
 
   if (scanPath === undefined && image === undefined) {
     throw new Error(
@@ -163,7 +165,8 @@ function configureScan(
   // if scanners haven't been set in the options, add them here
   if (
     !options.includes('--scanners') &&
-    !options.includes('--security-checks')
+    !options.includes('--security-checks') &&
+    scanners.length > 0
   ) {
     runner.arg(['--scanners', scanners]);
   }

--- a/trivy-task/task.json
+++ b/trivy-task/task.json
@@ -8,7 +8,7 @@
   "helpUrl": "https://github.com/aquasecurity/trivy-azure-pipelines-task",
   "category": "Test",
   "author": "Aqua Security",
-  "version": { "Major":1,"Minor":11,"Patch":85 },
+  "version": { "Major":1,"Minor":11,"Patch":97 },
   "instanceNameFormat": "Echo trivy $(version)",
   
   "groups": [
@@ -157,7 +157,7 @@
       "name": "scanners",
       "type": "string",
       "label": "Override scanners, comma separated",
-      "defaultValue": "vuln,misconfig,secret",
+      "defaultValue": "",
       "required": false,
       "helpMarkDown": "Choose which scanners to run (vuln, misconfig, secret).",
       "groupName": "scanning"

--- a/trivy-task/task.json.tmpl
+++ b/trivy-task/task.json.tmpl
@@ -157,7 +157,7 @@
       "name": "scanners",
       "type": "string",
       "label": "Override scanners, comma separated",
-      "defaultValue": "vuln,misconfig,secret",
+      "defaultValue": "",
       "required": false,
       "helpMarkDown": "Choose which scanners to run (vuln, misconfig, secret).",
       "groupName": "scanning"


### PR DESCRIPTION
if scanners isn't specified, trivy will automatically use `vuln,secret`.
If the scanners input is empty and the user doesn't override it, then it
wont be set
