### PR TITLE
fix: ensure that the cache folder is created

### DIFF
--- a/trivy-task/trivyLoader.ts
+++ b/trivy-task/trivyLoader.ts
@@ -50,6 +50,10 @@ export async function createRunner(): Promise<ToolRunner> {
   const home = homedir();
   const cwd = process.cwd();
   const dockerHome = home + '/.docker';
+  const cacheDir = tmpPath + '.cache';
+
+  // ensure the cache dir is created
+  task.mkdirP(cacheDir);
 
   // ensure the docker home dir is created
   task.mkdirP(dockerHome);


### PR DESCRIPTION
To prevent the Trivy docker container from creating the .cache folder
when it doesn't exist, ensure that it is created up front

```
➜  azure-agent  ls _work/_temp/     
drwxrwxr-x - agent  6 Mar 10:39  .cache
drwxrwxr-x - agent 26 Feb 14:21  __default-support
drwxrwxr-x - agent  6 Mar 10:38  contrib
```

Resolves #126 