### PR TITLE
fix: Return the latest version

### DIFF
--- a/trivy-task/trivyLoader.ts
+++ b/trivy-task/trivyLoader.ts
@@ -174,6 +174,7 @@ async function getLatestTrivyVersion(): Promise<string> {
     if (parts) {
       const latestVersion = parts[parts.length - 1];
       console.log(`Latest Trivy version is ${latestVersion}`);
+      return latestVersion;
     }
   } catch (error) {
     console.log(

--- a/trivy-task/trivyLoader.ts
+++ b/trivy-task/trivyLoader.ts
@@ -43,7 +43,10 @@ export async function createRunner(): Promise<ToolRunner> {
   }
 
   // Fail-fast on Microsoft Hosted agents on non-Linux platforms
-  if (task.getAgentMode() === task.AgentHostedMode.MsHosted && task.getPlatform() !== task.Platform.Linux) {
+  if (
+    task.getAgentMode() === task.AgentHostedMode.MsHosted &&
+    task.getPlatform() !== task.Platform.Linux
+  ) {
     throw new Error('Running Trivy in docker is available on Linux only.');
   }
   return dockerRunner(version);


### PR DESCRIPTION
The latest version was being taken from GitHub but not returned so it
was always using the fallback version.

This small fix corrects that and Resolves #85

```
Run requested using local Trivy binary...
Finding correct Trivy version to install...
Fetching latest Trivy version from GitHub...
Latest Trivy version is v0.60.0
Downloading Trivy...
Downloading: https://github.com/aquasecurity/trivy/releases/download/v0.60.0/trivy_0.60.0_Linux-64bit.tar.gz
Extracting Trivy...
Extracting archive
/usr/bin/tar xC /home/owen/azure-agent/_work/_temp/ -f /home/owen/azure-agent/_work/_temp/6a916875-fbc7-4988-a28e-93e514b45cc3

Setting permissions...
/usr/bin/chmod +x /home/owen/azure-agent/_work/_tool/trivy_0_60_0
Configuring options for image scan...
/home/owen/azure-agent/_work/_tool/trivy_0_60_0 fs --exit-code 0 --format json --output /home/owen/azure-agent/_work/_temp/trivy-results-0.3662308091145954.json --scanners vuln,misconfig --db-repository ghcr.io/aquasecurity/trivy-db:2,aquasec/trivy-db:2 .
2025-03-08T07:36:38Z	INFO	[vuln] Vulnerability scanning is enabled
2025-03-08T07:36:38Z	INFO	[misconfig] Misconfiguration scanning is enabled
2025-03-08T07:36:38Z	INFO	Number of language-specific files	num=2
2025-03-08T07:36:38Z	INFO	[cargo] Detecting vulnerabilities...
2025-03-08T07:36:38Z	INFO	[pipenv] Detecting vulnerabilities...
2025-03-08T07:36:38Z	INFO	Detected config files	num=1
Done!
Finishing: Trivy Scan

```
