### PR TITLE
fix: auqa plugin installation in docker

### DIFF
--- a/trivy-task/trivyV1/trivyLoader.ts
+++ b/trivy-task/trivyV1/trivyLoader.ts
@@ -58,7 +58,11 @@ async function dockerRunner(inputs: TaskInputs): Promise<ToolRunner> {
       runner.line('-e AQUA_URL=https://api.dev.supply-chain.cloud.aquasec.com');
       runner.line('-e CSPM_URL=https://stage.api.cloudsploit.com');
     }
+    // https://trivy.dev/latest/docs/plugin/user-guide/#installing-plugins
+    runner.line(`-e XDG_DATA_HOME=${tmpPath}`);
+    task.mkdirP(path.join(tmpPath, '.trivy', 'plugins'));
   }
+
   const trivyImage =
     inputs.trivyImage === 'aquasec/trivy'
       ? `${inputs.trivyImage}:${stripV(inputs.version)}`

--- a/trivy-task/trivyV2/runner.ts
+++ b/trivy-task/trivyV2/runner.ts
@@ -50,6 +50,9 @@ async function dockerRunner(inputs: TaskInputs): Promise<ToolRunner> {
     runner.line('-e OVERRIDE_BRANCH');
     runner.line('-e OVERRIDE_REPOSITORY');
     runner.line('-e TRIVY_RUN_AS_PLUGIN');
+    // https://trivy.dev/latest/docs/plugin/user-guide/#installing-plugins
+    runner.line(`-e XDG_DATA_HOME=${tmpPath}`);
+    task.mkdirP(path.join(tmpPath, '.trivy', 'plugins'));
   }
 
   const trivyImage =


### PR DESCRIPTION
Set `XDG_DATA_HOME` to writable location and create directory for plugins as described in [docs](https://trivy.dev/latest/docs/plugin/user-guide/#installing-plugins)

Fixes #159 

