### PR TITLE
feat: add sbom to the types for v2

### DIFF
--- a/trivy-task/trivyV1/index.ts
+++ b/trivy-task/trivyV1/index.ts
@@ -88,6 +88,7 @@ function configureScan(runner: ToolRunner, inputs: TaskInputs, output: string) {
   runner.arg(['--exit-code', inputs.exitCode]);
   runner.arg(['--format', 'json']);
   runner.arg(['--output', output]);
+  runner.arg('--list-all-pkgs');
   runner.argIf(inputs.severities, ['--severity', inputs.severities]);
   runner.argIf(inputs.ignoreUnfixed, ['--ignore-unfixed']);
 

--- a/trivy-task/trivyV2/index.ts
+++ b/trivy-task/trivyV2/index.ts
@@ -78,6 +78,7 @@ function configureScan(runner: ToolRunner, inputs: TaskInputs) {
   runner.arg(['--exit-code', '2']);
   runner.arg(['--format', 'json']);
   runner.argIf(inputs.scanners, ['--scanners', inputs.scanners]);
+  runner.arg('--list-all-pkgs');
   runner.argIf(inputs.severities, ['--severity', inputs.severities]);
   runner.argIf(inputs.ignoreUnfixed, ['--ignore-unfixed']);
   runner.arg(['--output', resultsFilePath]);

--- a/trivy-task/trivyV2/task.json
+++ b/trivy-task/trivyV2/task.json
@@ -93,7 +93,8 @@
       "options": {
         "filesystem": "filesystem",
         "image": "image",
-        "repository": "repository"
+        "repository": "repository",
+        "sbom": "sbom"
       }
     },
     {


### PR DESCRIPTION
- enable sbom as a scanning type for v2
- update the trivy run for both version to include all packages to fix
  issue where the sbom conversion doesn't have all the data

Signed-off-by: Owen Rumney <owen.rumney@aquasec.com>
