### PR TITLE
chore: set the lowest v2 support to node16

### DIFF
--- a/trivy-task/trivyV2/task.json
+++ b/trivy-task/trivyV2/task.json
@@ -10,7 +10,7 @@
   "author": "Aqua Security",
   "version": {
     "Major": 2,
-    "Minor": 2,
+    "Minor": 3,
     "Patch": 0
   },
   "instanceNameFormat": "Echo trivy $(version)",
@@ -211,7 +211,7 @@
     "Node20_1": {
       "target": "dist/index.js"
     },
-    "Node10": {
+    "Node16": {
       "target": "dist/index.js"
     }
   }


### PR DESCRIPTION
The trivy task uses syntax introduced in node14 so we should not be
supporting Node10 for this task.

Add support for Node16

Fixes #169

Signed-off-by: Owen Rumney <owen.rumney@aquasec.com>
