### PR TITLE
docs: update the instructions for docker scanning

### DIFF
--- a/docs/trivyv2.md
+++ b/docs/trivyv2.md
@@ -111,7 +111,7 @@ steps:
   - task: trivy@2
     inputs:
       type: 'image'
-      image: my.private.registry/org/my-image:latest
+      target: my.private.registry/org/my-image:latest
 ```
 
 ### Scanning with Aqua Platform support


### PR DESCRIPTION
Update the the docs for v2 to direct user to use `target` rather than
`image`

Resolves #179

Signed-off-by: Owen Rumney <owen.rumney@aquasec.com>
