### PR TITLE
feat: add fail on severity threshold

### DIFF
--- a/docs/trivyv2.md
+++ b/docs/trivyv2.md
@@ -35,14 +35,15 @@ For more information about creating the connected service, see [Configuring Aqua
 
 ### Scan Options
 
-| Input              | Type     | Defaults | Description                                                                                                                        |
-| ------------------ | -------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `type`             | pickList |          | The type of scan to perform. Options: `filesystem`, `image`, `repository`.                                                         |
-| `target`           | string   |          | The specified target will be scanned using the selected scan type.                                                                 |
-| `scanners`         | pickList |          | Choose which scanners to run. Options: `license`, `misconfig`, `secret`, `vuln`. Multi-select is supported.                        |
-| `severities`       | pickList |          | Severities of security issues to be displayed. Options: `UNKNOWN`, `LOW`, `MEDIUM`, `HIGH`, `CRITICAL`. Multi-select is supported. |
-| `ignoreUnfixed`    | boolean  | false    | Include only fixed vulnerabilities.                                                                                                |
-| `ignoreScanErrors` | boolean  | false    | Ignore scan errors and continue the pipeline with a `SucceededWithIssues` result.                                                  |
+| Input                     | Type     | Defaults | Description                                                                                                                                                                                                                                                   |
+| ------------------------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `type`                    | pickList |          | The type of scan to perform. Options: `filesystem`, `image`, `repository`.                                                                                                                                                                                    |
+| `target`                  | string   |          | The specified target will be scanned using the selected scan type.                                                                                                                                                                                            |
+| `scanners`                | pickList |          | Choose which scanners to run. Options: `license`, `misconfig`, `secret`, `vuln`. Multi-select is supported.                                                                                                                                                   |
+| `severities`              | pickList |          | Severities of security issues to be displayed. Options: `UNKNOWN`, `LOW`, `MEDIUM`, `HIGH`, `CRITICAL`. Multi-select is supported.                                                                                                                            |
+| `ignoreUnfixed`           | boolean  | false    | Include only fixed vulnerabilities.                                                                                                                                                                                                                           |
+| `failOnSeverityThreshold` | pickList |          | Set a threshold for failing the task based on the highest severity level found during the scan. If set, the task will fail if any issue with a severity equal to or higher than this level is found. Options: `UNKNOWN`, `LOW`, `MEDIUM`, `HIGH`, `CRITICAL`. |
+| `ignoreScanErrors`        | boolean  | false    | Ignore scan errors and continue the pipeline with a `SucceededWithIssues` result.                                                                                                                                                                             |
 
 ---
 

--- a/trivy-task/trivyV1/task.json
+++ b/trivy-task/trivyV1/task.json
@@ -10,8 +10,8 @@
   "author": "Aqua Security",
   "version": {
     "Major": 1,
-    "Minor": 16,
-    "Patch": 0
+    "Minor": 18,
+    "Patch": 2
   },
   "instanceNameFormat": "Echo trivy $(version)",
   "groups": [

--- a/trivy-task/trivyV2/inputs.ts
+++ b/trivy-task/trivyV2/inputs.ts
@@ -15,6 +15,7 @@ export type TaskInputs = {
   ignoreUnfixed: boolean;
   showSuppressed: boolean;
   ignoreScanErrors: boolean;
+  failOnSeverityThreshold: string;
   hasAquaAccount: boolean;
   aquaKey?: string;
   aquaSecret?: string;
@@ -45,6 +46,8 @@ export function getTaskInputs(): TaskInputs {
     ignoreUnfixed: task.getBoolInput('ignoreUnfixed', false),
     showSuppressed: task.getBoolInput('showSuppressed', false),
     ignoreScanErrors: task.getBoolInput('ignoreScanErrors', false),
+    failOnSeverityThreshold:
+      task.getInput('failOnSeverityThreshold', false) ?? '',
     reports: task.getDelimitedInput('reports', ',').map((s) => s.trim()),
     publish: task.getBoolInput('publish', false),
     templates: task.getInput('templates', false),

--- a/trivy-task/trivyV2/task.json
+++ b/trivy-task/trivyV2/task.json
@@ -10,8 +10,8 @@
   "author": "Aqua Security",
   "version": {
     "Major": 2,
-    "Minor": 4,
-    "Patch": 0
+    "Minor": 5,
+    "Patch": 2
   },
   "instanceNameFormat": "Echo trivy $(version)",
   "groups": [
@@ -170,6 +170,26 @@
       "defaultValue": "false",
       "required": false,
       "helpMarkDown": "Ignore scan errors and continue the pipeline with `SucceededWithIssues` result."
+    },
+    {
+      "groupName": "scanInput",
+      "name": "failOnSeverityThreshold",
+      "type": "pickList",
+      "label": "Fail on Severity Level Threshold",
+      "defaultValue": "",
+      "required": false,
+      "options": {
+        "UNKNOWN": "UNKNOWN",
+        "LOW": "LOW",
+        "MEDIUM": "MEDIUM",
+        "HIGH": "HIGH",
+        "CRITICAL": "CRITICAL"
+      },
+      "helpMarkDown": "Set a threshold for failing the task based on the highest severity level found during the scan. If set, the task will fail if any issue with a severity equal to or higher than this level is found.",
+      "properties": {
+        "EditableOptions": "False",
+        "MultiSelectFlatList": "False"
+      }
     },
     {
       "groupName": "reportsInput",

--- a/trivy-task/trivyV2/utils.ts
+++ b/trivy-task/trivyV2/utils.ts
@@ -9,3 +9,48 @@ export function stripV(version: string): string {
   }
   return version;
 }
+
+export const severityLevels = ['UNKNOWN', 'LOW', 'MEDIUM', 'HIGH', 'CRITICAL'];
+
+export function getHighestSeverityLevel(resultFilePath: string): string {
+  let highestIndex = -1;
+
+  try {
+    const data = require(resultFilePath);
+    if (data && data.Results) {
+      for (const result of data.Results) {
+        if (result.Vulnerabilities) {
+          for (const vulnerability of result.Vulnerabilities) {
+            const severity = vulnerability.Severity;
+            const index = severityLevels.indexOf(severity);
+            if (index > highestIndex) {
+              highestIndex = index;
+            }
+          }
+        }
+        if (result.Misconfigurations) {
+          for (const misconfiguration of result.Misconfigurations) {
+            const severity = misconfiguration.Severity;
+            const index = severityLevels.indexOf(severity);
+            if (index > highestIndex) {
+              highestIndex = index;
+            }
+          }
+        }
+        if (result.Secrets) {
+          for (const secret of result.Secrets) {
+            const severity = secret.Severity;
+            const index = severityLevels.indexOf(severity);
+            if (index > highestIndex) {
+              highestIndex = index;
+            }
+          }
+        }
+      }
+    }
+  } catch (error) {
+    console.error(`Error reading or parsing the result file: ${error}`);
+  }
+
+  return highestIndex >= 0 ? severityLevels[highestIndex] : '';
+}


### PR DESCRIPTION
Add an input to the v2 Trivy task to specify a threshold severity, lower
than this severity at and the task will report succeeded.

If the ignore errors is set to true, but the threshold is breached then
it will be a SucceededWithIssues

Closes #182
