### PR TITLE
feat: add custom url for trivy

### DIFF
--- a/trivy-task/trivyV1/installer.ts
+++ b/trivy-task/trivyV1/installer.ts
@@ -1,32 +1,32 @@
 import os from 'os';
 import tool = require('azure-pipelines-tool-lib');
 import task = require('azure-pipelines-task-lib/task');
-import { stripV } from './utils';
+import { stripV, TaskInputs } from './utils';
 
 const fallbackVersion = 'v0.60.0';
 const releasesUri = 'https://github.com/aquasecurity/trivy/releases';
 let isInstalled = false;
 
-export async function installTrivy(version: string) {
+export async function installTrivy(inputs: TaskInputs) {
   if (isInstalled) {
     // Skip installation if already installed
     return;
   }
 
-  console.log(`Requested Trivy version to install: ${version}`);
-  if (version === 'latest') {
-    version = await getLatestVersion();
+  console.log(`Requested Trivy version to install: ${inputs.version}`);
+  if (inputs.version === 'latest') {
+    inputs.version = await getLatestVersion();
   }
 
-  let cachedPath = tool.findLocalTool('trivy', version);
+  let cachedPath = tool.findLocalTool('trivy', inputs.version);
   if (!cachedPath) {
-    const url = await getArtifactURL(version);
+    const url = await getArtifactURL(inputs);
     const downloadPath = await tool.downloadTool(url);
     const extractPath =
       getPlatform() === 'windows'
         ? await tool.extractZip(downloadPath)
         : await tool.extractTar(downloadPath);
-    cachedPath = await tool.cacheDir(extractPath, 'trivy', version);
+    cachedPath = await tool.cacheDir(extractPath, 'trivy', inputs.version);
   }
   tool.prependPath(cachedPath);
   isInstalled = true;
@@ -49,11 +49,16 @@ async function getLatestVersion(): Promise<string> {
   return version;
 }
 
-async function getArtifactURL(version: string): Promise<string> {
+async function getArtifactURL(inputs: TaskInputs): Promise<string> {
+  if (inputs.trivyUrl) {
+    console.log(`Using custom Trivy URL: ${inputs.trivyUrl}`);
+    return inputs.trivyUrl;
+  }
+
   const arch = getArchitecture();
   const platform = getPlatform();
   const extension = platform === 'windows' ? '.zip' : '.tar.gz';
-  return `${releasesUri}/download/${version}/trivy_${stripV(version)}_${platform}-${arch}${extension}`;
+  return `${releasesUri}/download/${inputs.version}/trivy_${stripV(inputs.version)}_${platform}-${arch}${extension}`;
 }
 
 function getArchitecture(): string {

--- a/trivy-task/trivyV1/task.json
+++ b/trivy-task/trivyV1/task.json
@@ -87,6 +87,16 @@
       "visibleRule": "docker = false"
     },
     {
+      "name": "trivyUrl",
+      "type": "string",
+      "label": "Custom Trivy Download URL",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "Specify a custom URL to download Trivy from. If this option is used, the 'version' option is ignored.",
+      "groupName": "trivyRunner",
+      "visibleRule": "useSystemInstallation = false && docker = false"
+    },
+    {
       "name": "version",
       "type": "string",
       "label": "Trivy Version",

--- a/trivy-task/trivyV1/trivyLoader.ts
+++ b/trivy-task/trivyV1/trivyLoader.ts
@@ -19,7 +19,7 @@ export async function createRunner(inputs: TaskInputs): Promise<ToolRunner> {
   if (inputs.useSystem) {
     console.log('Run requested using system Trivy binary...');
   } else {
-    await installTrivy(inputs.version);
+    await installTrivy(inputs);
   }
   return task.tool('trivy');
 }

--- a/trivy-task/trivyV1/utils.ts
+++ b/trivy-task/trivyV1/utils.ts
@@ -25,6 +25,7 @@ export type TaskInputs = {
   spdxjsonOutput?: boolean;
   tableOutput?: boolean;
   options: string;
+  trivyUrl?: string;
 };
 
 /**
@@ -56,6 +57,7 @@ export function getTaskInputs(): TaskInputs {
     spdxjsonOutput: task.getBoolInput('spdxjsonOutput', false),
     tableOutput: task.getBoolInput('tableOutput', false),
     options: task.getInput('options', false) ?? '',
+    trivyUrl: task.getInput('trivyUrl', false) ?? '',
   };
   validateInputs(inputs);
   return inputs;

--- a/trivy-task/trivyV2/inputs.ts
+++ b/trivy-task/trivyV2/inputs.ts
@@ -21,6 +21,7 @@ export type TaskInputs = {
   aquaSecret?: string;
   aquaUrl?: string;
   authUrl?: string;
+  trivyUrl?: string;
 };
 
 /**
@@ -68,5 +69,6 @@ export function getTaskInputs(): TaskInputs {
       'authUrl',
       true
     ),
+    trivyUrl: task.getInput('trivyUrl', false) ?? '',
   };
 }

--- a/trivy-task/trivyV2/runner.ts
+++ b/trivy-task/trivyV2/runner.ts
@@ -14,7 +14,7 @@ export async function createRunner(inputs: TaskInputs): Promise<ToolRunner> {
     case 'docker':
       return dockerRunner(inputs);
     case 'install':
-      await installTrivy(inputs.version);
+      await installTrivy(inputs);
       return task.tool('trivy');
     case 'system':
       console.log('Run requested using system Trivy binary...');

--- a/trivy-task/trivyV2/task.json
+++ b/trivy-task/trivyV2/task.json
@@ -66,6 +66,16 @@
     },
     {
       "groupName": "runnerInput",
+      "name": "trivyUrl",
+      "type": "string",
+      "label": "Custom Trivy Download URL",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "Specify a custom URL to download Trivy from. If this option is used, the 'version' option is ignored.",
+      "visibleRule": "method != system && method != docker"
+    },
+    {
+      "groupName": "runnerInput",
       "name": "version",
       "type": "string",
       "label": "Trivy Version",


### PR DESCRIPTION
Add support for installing Trivy from a custom url
- updated in trivyV1 and trivyV2

Example output when `trivyUrl` provided.

It is assumed that the `trivyUrl` will be a tar or zip as is available from Trivy releases

```
Starting: Container Scan loki-canary
==============================================================================
Task         : Trivy [Dev]
Description  : Trivy is the world's most popular open source vulnerability and misconfiguration scanner. It is reliable, fast, extremely easy to use, and it works wherever you need it.
Version      : 1.19.8
Author       : Aqua Security
Help         : https://github.com/aquasecurity/trivy-azure-pipelines-task/docs/trivyv1.md
==============================================================================
Requested Trivy version to install: latest
Resolved version: v0.67.2
Using custom Trivy URL: https://github.com/aquasecurity/trivy/releases/download/v0.67.2/trivy_0.67.2_Linux-64bit.tar.gz
Downloading: https://github.com/aquasecurity/trivy/releases/download/v0.67.2/trivy_0.67.2_Linux-64bit.tar.gz
Extracting archive
/usr/bin/tar xC /home/vsts/work/_temp/f420f7df-5daf-486f-84c4-b73c864b7872 -f /home/vsts/work/_temp/197fa6f7-e8de-42c0-abba-9f6841dac44a

Caching tool: trivy 0.67.2 x64
```
