### PR TITLE
fix: Don't resolve the path for ca cert

### DIFF
--- a/trivy-task/trivyV1/utils.ts
+++ b/trivy-task/trivyV1/utils.ts
@@ -60,7 +60,7 @@ export function getTaskInputs(): TaskInputs {
     tableOutput: task.getBoolInput('tableOutput', false),
     options: task.getInput('options', false) ?? '',
     trivyUrl: task.getInput('trivyUrl', false) ?? '',
-    customCaCertPath: task.getPathInput('customCaCertPath', false),
+    customCaCertPath: task.getInput('customCaCertPath', false) ?? undefined,
     skipDownloadCertificateChecking: task.getBoolInput(
       'skipDownloadCertificateChecking',
       false

--- a/trivy-task/trivyV2/inputs.ts
+++ b/trivy-task/trivyV2/inputs.ts
@@ -72,7 +72,7 @@ export function getTaskInputs(): TaskInputs {
       true
     ),
     trivyUrl: task.getInput('trivyUrl', false) ?? '',
-    customCaCertPath: task.getPathInput('customCaCertPath', false),
+    customCaCertPath: task.getInput('customCaCertPath', false) ?? undefined,
     skipDownloadCertificateChecking: task.getBoolInput(
       'skipDownloadCertificateChecking',
       false


### PR DESCRIPTION
The getPathInput will always resolve a path even when no value is set so
we need to getInput or undefined to accurately solve this
