### PR TITLE
fix: Trivy URL download with self signed cert

### DIFF
--- a/trivy-task/trivyV1/task.json
+++ b/trivy-task/trivyV1/task.json
@@ -10,7 +10,7 @@
   "author": "Aqua Security",
   "version": {
     "Major": 1,
-    "Minor": 19,
+    "Minor": 20,
     "Patch": 1
   },
   "instanceNameFormat": "Echo trivy $(version)",
@@ -92,29 +92,9 @@
       "label": "Custom Trivy Download URL",
       "defaultValue": "",
       "required": false,
-      "helpMarkDown": "Specify a custom URL to download Trivy from. If this option is used, the 'version' option is ignored.",
+      "helpMarkDown": "Specify a custom URL to download Trivy from. If this option is used, the 'version' must be set to a specific version.",
       "groupName": "trivyRunner",
       "visibleRule": "useSystemInstallation = false && docker = false"
-    },
-    {
-      "name": "customCaCertPath",
-      "type": "filePath",
-      "label": "Custom CA Certificate Path",
-      "defaultValue": "",
-      "required": false,
-      "helpMarkDown": "Path to a custom CA certificate file on the agent to trust when downloading Trivy. This is the recommended approach for self-signed certificates.",
-      "groupName": "trivyRunner",
-      "visibleRule": "trivyUrl != \"\""
-    },
-    {
-      "groupName": "trivyRunner",
-      "name": "skipDownloadCertificateChecking",
-      "type": "boolean",
-      "label": "Skip Download Certificate Checking",
-      "defaultValue": false,
-      "required": false,
-      "helpMarkDown": "Skip the certificate checking when downloading Trivy from a custom URL. This is useful when the custom URL is self-signed or has a certificate that is not trusted by the system but care should be taken to ensure the security of the system.",
-      "visibleRule": "trivyUrl != \"\""
     },
     {
       "name": "version",

--- a/trivy-task/trivyV1/utils.ts
+++ b/trivy-task/trivyV1/utils.ts
@@ -26,8 +26,6 @@ export type TaskInputs = {
   tableOutput?: boolean;
   options: string;
   trivyUrl?: string;
-  customCaCertPath?: string;
-  skipDownloadCertificateChecking: boolean;
 };
 
 /**
@@ -60,11 +58,6 @@ export function getTaskInputs(): TaskInputs {
     tableOutput: task.getBoolInput('tableOutput', false),
     options: task.getInput('options', false) ?? '',
     trivyUrl: task.getInput('trivyUrl', false) ?? '',
-    customCaCertPath: task.getInput('customCaCertPath', false) ?? undefined,
-    skipDownloadCertificateChecking: task.getBoolInput(
-      'skipDownloadCertificateChecking',
-      false
-    ),
   };
   validateInputs(inputs);
   return inputs;

--- a/trivy-task/trivyV2/inputs.ts
+++ b/trivy-task/trivyV2/inputs.ts
@@ -22,8 +22,6 @@ export type TaskInputs = {
   aquaUrl?: string;
   authUrl?: string;
   trivyUrl?: string;
-  customCaCertPath?: string;
-  skipDownloadCertificateChecking: boolean;
 };
 
 /**
@@ -72,10 +70,5 @@ export function getTaskInputs(): TaskInputs {
       true
     ),
     trivyUrl: task.getInput('trivyUrl', false) ?? '',
-    customCaCertPath: task.getInput('customCaCertPath', false) ?? undefined,
-    skipDownloadCertificateChecking: task.getBoolInput(
-      'skipDownloadCertificateChecking',
-      false
-    ),
   };
 }

--- a/trivy-task/trivyV2/installer.ts
+++ b/trivy-task/trivyV2/installer.ts
@@ -26,23 +26,18 @@ export async function installTrivy(inputs: TaskInputs): Promise<void> {
   if (!cachedPath) {
     const url = await getArtifactURL(inputs);
 
-    if (inputs.trivyUrl && inputs.customCaCertPath) {
-      console.log(`Using custom CA certificate: ${inputs.customCaCertPath}`);
-      process.env.NODE_EXTRA_CA_CERTS = inputs.customCaCertPath;
-    } else if (inputs.trivyUrl && inputs.skipDownloadCertificateChecking) {
-      task.warning(
-        '⚠️  Certificate validation is disabled for Trivy download. This is insecure and should only be used in trusted environments.'
+    if (process.env.NODE_EXTRA_CA_CERTS) {
+      task.debug(
+        `NODE_EXTRA_CA_CERTS is set: ${process.env.NODE_EXTRA_CA_CERTS}`
       );
-      process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+    }
+    if (process.env.NODE_TLS_REJECT_UNAUTHORIZED) {
+      task.debug(
+        `NODE_TLS_REJECT_UNAUTHORIZED is set: ${process.env.NODE_TLS_REJECT_UNAUTHORIZED}`
+      );
     }
 
     const downloadPath = await tool.downloadTool(url);
-
-    if (inputs.trivyUrl && inputs.customCaCertPath) {
-      delete process.env.NODE_EXTRA_CA_CERTS;
-    } else if (inputs.trivyUrl && inputs.skipDownloadCertificateChecking) {
-      delete process.env.NODE_TLS_REJECT_UNAUTHORIZED;
-    }
 
     const extractPath =
       getPlatform() === 'windows'
@@ -73,6 +68,11 @@ async function getLatestVersion(): Promise<string> {
 
 async function getArtifactURL(inputs: TaskInputs): Promise<string> {
   if (inputs.trivyUrl) {
+    if (inputs.version === 'latest') {
+      // fail the task because a specific version is required when using a custom URL
+      throw new Error('A specific version is required when using a custom URL');
+    }
+
     console.log(`Using custom Trivy URL: ${inputs.trivyUrl}`);
     return inputs.trivyUrl;
   }

--- a/trivy-task/trivyV2/task.json
+++ b/trivy-task/trivyV2/task.json
@@ -10,7 +10,7 @@
   "author": "Aqua Security",
   "version": {
     "Major": 2,
-    "Minor": 6,
+    "Minor": 7,
     "Patch": 1
   },
   "instanceNameFormat": "Echo trivy $(version)",
@@ -71,7 +71,7 @@
       "label": "Custom Trivy Download URL",
       "defaultValue": "",
       "required": false,
-      "helpMarkDown": "Specify a custom URL to download Trivy from. If this option is used, the 'version' option is ignored.",
+      "helpMarkDown": "Specify a custom URL to download Trivy from. If this option is used, the 'version' must be set to a specific version.",
       "visibleRule": "method != system && method != docker"
     },
     {


### PR DESCRIPTION
When using the self signed certs with a trivyUrl, the previously added
inputs will not work because they need to be set at the time of the
Node process being run.

The user must set the env variable of `NODE_EXTRA_CA_CERTS` or
`NODE_TLS_REJECT_UNAUTHORIZED=1` in the task definition
