### PR TITLE
Use the task library namespace instead of a missing default export

### DIFF
--- a/trivy-task/trivyV2/package.json
+++ b/trivy-task/trivyV2/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "test": "tsc taskFlowStandalone.ts scanResultLogic.ts --outDir dist --esModuleInterop --skipLibCheck --module commonjs --target es2019 --moduleResolution node && node scripts/taskFlow.test.js && node scripts/scanResultLogic.test.js",
+    "test": "tsc taskFlow.ts taskFlowStandalone.ts scanResultLogic.ts --outDir dist --esModuleInterop --skipLibCheck --module commonjs --target es2019 --moduleResolution node && node scripts/taskFlow.test.js && node scripts/scanResultLogic.test.js && node scripts/publishAssuranceResults.test.js",
     "build": "tsc -b tsconfig.json"
   },
   "dependencies": {

--- a/trivy-task/trivyV2/scripts/publishAssuranceResults.test.js
+++ b/trivy-task/trivyV2/scripts/publishAssuranceResults.test.js
@@ -1,0 +1,18 @@
+const assert = require('assert');
+const path = require('path');
+const { publishAssuranceResults } = require('../dist/taskFlow');
+
+async function run() {
+  // hasAquaAccount is what takes the code into the task library, which is
+  // where the missing default export used to surface as
+  // "Cannot read properties of undefined (reading 'exist')".
+  const missing = path.join(__dirname, 'no-such-assurance-file.json');
+  await publishAssuranceResults({ hasAquaAccount: true }, missing, 'assurance.json');
+
+  console.log('ok publishAssuranceResults reaches the task library');
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/trivy-task/trivyV2/taskFlow.ts
+++ b/trivy-task/trivyV2/taskFlow.ts
@@ -41,7 +41,10 @@ export async function publishAssuranceResults(
   assuranceFilePath: string,
   assuranceFileName: string
 ) {
-  const task = (await import('azure-pipelines-task-lib/task')).default;
+  // azure-pipelines-task-lib/task is a CommonJS module that sets __esModule,
+  // so it has no default export and the namespace is what carries exist() and
+  // addAttachment().
+  const task = await import('azure-pipelines-task-lib/task');
 
   if (inputs.hasAquaAccount && task.exist(assuranceFilePath)) {
     console.log('Publishing JSON assurance results...');


### PR DESCRIPTION
Fixes #228.

`publishAssuranceResults` loads the task library as `(await import('azure-pipelines-task-lib/task')).default`. That module is TypeScript compiled to CommonJS, so it sets `__esModule` and exports no `default`; the interop helper therefore hands back `undefined` and the next line throws `Cannot read properties of undefined (reading 'exist')`. That is the failure in the report, and it fires whenever the run has an Aqua account configured, which is the only path that reaches this function.

Checked against the installed dependency:

```
$ node -e "const m = require('azure-pipelines-task-lib/task'); console.log(m.__esModule, typeof m.default, typeof m.exist)"
true undefined function
```

The namespace is what carries `exist` and `addAttachment`, so the `.default` goes away. Every other module in `trivyV2` already reaches the library through `import task = require('azure-pipelines-task-lib/task')`; this file uses the dynamic form so the standalone test build does not have to pull the library in, so I kept the dynamic import rather than switching the style.

`scripts/publishAssuranceResults.test.js` calls the function with `hasAquaAccount` set and a path that does not exist, which is enough to reach the library and return without publishing anything. The test compiles `taskFlow.ts` alongside the two files the suite already builds. Before the change it fails with the exact `TypeError` from the issue; after it prints `ok publishAssuranceResults reaches the task library`.

`npm test --prefix trivy-task/trivyV2` passes, and prettier is happy with the three changed files.
