### PR TITLE
Fix/slk 133923 assurance task import

### DIFF
--- a/trivy-task/trivyV2/package.json
+++ b/trivy-task/trivyV2/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "test": "tsc taskFlowStandalone.ts scanResultLogic.ts --outDir dist --esModuleInterop --skipLibCheck --module commonjs --target es2019 --moduleResolution node && node scripts/taskFlow.test.js && node scripts/scanResultLogic.test.js",
+    "test": "tsc taskFlowStandalone.ts scanResultLogic.ts taskFlow.ts --outDir dist --esModuleInterop --skipLibCheck --module commonjs --target es2019 --moduleResolution node && node scripts/taskFlow.test.js && node scripts/publishAssuranceResults.test.js && node scripts/scanResultLogic.test.js",
     "build": "tsc -b tsconfig.json"
   },
   "dependencies": {

--- a/trivy-task/trivyV2/package.json
+++ b/trivy-task/trivyV2/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "test": "tsc taskFlowStandalone.ts scanResultLogic.ts taskFlow.ts --outDir dist --esModuleInterop --skipLibCheck --module commonjs --target es2019 --moduleResolution node && node scripts/taskFlow.test.js && node scripts/publishAssuranceResults.test.js && node scripts/scanResultLogic.test.js",
+    "test": "npm run build && tsc taskFlowStandalone.ts --outDir dist --esModuleInterop --skipLibCheck --module commonjs --target es2019 --moduleResolution node && node scripts/taskFlow.test.js && node scripts/publishAssuranceResults.test.js && node scripts/scanResultLogic.test.js",
     "build": "tsc -b tsconfig.json"
   },
   "dependencies": {

--- a/trivy-task/trivyV2/scripts/publishAssuranceResults.test.js
+++ b/trivy-task/trivyV2/scripts/publishAssuranceResults.test.js
@@ -22,14 +22,9 @@ function loadPublishAssuranceResults(mockTask) {
 }
 
 async function run() {
-  const taskFlowJs = fs.readFileSync(
-    path.resolve(__dirname, '../dist/taskFlow.js'),
-    'utf8'
-  );
+  const taskFlowJs = fs.readFileSync(path.resolve(__dirname, '../dist/taskFlow.js'), 'utf8');
   assert.ok(
-    !taskFlowJs.includes(
-      "__importStar(require('azure-pipelines-task-lib/task'))).default"
-    ),
+    !taskFlowJs.includes("__importStar(require('azure-pipelines-task-lib/task'))).default"),
     'compiled taskFlow must not read task-lib through .default'
   );
   assert.match(
@@ -51,11 +46,7 @@ async function run() {
 
   const publishAssuranceResults = loadPublishAssuranceResults(mockTask);
 
-  await publishAssuranceResults(
-    { hasAquaAccount: true },
-    '/tmp/trivy-assurance.json',
-    'trivy-assurance.json'
-  );
+  await publishAssuranceResults({ hasAquaAccount: true }, '/tmp/trivy-assurance.json', 'trivy-assurance.json');
 
   assert.deepStrictEqual(calls.exist, ['/tmp/trivy-assurance.json']);
   assert.deepStrictEqual(calls.addAttachment, [
@@ -65,11 +56,7 @@ async function run() {
   calls.exist.length = 0;
   calls.addAttachment.length = 0;
 
-  await publishAssuranceResults(
-    { hasAquaAccount: false },
-    '/tmp/trivy-assurance.json',
-    'trivy-assurance.json'
-  );
+  await publishAssuranceResults({ hasAquaAccount: false }, '/tmp/trivy-assurance.json', 'trivy-assurance.json');
 
   assert.deepStrictEqual(calls.exist, []);
   assert.deepStrictEqual(calls.addAttachment, []);
@@ -84,28 +71,18 @@ async function run() {
     },
   });
 
-  await publishWhenMissing(
-    { hasAquaAccount: true },
-    '/tmp/missing-assurance.json',
-    'missing-assurance.json'
-  );
+  await publishWhenMissing({ hasAquaAccount: true }, '/tmp/missing-assurance.json', 'missing-assurance.json');
 
   assert.deepStrictEqual(calls.addAttachment, []);
 
   const brokenTaskImport = (() => {
     const taskLib = { __esModule: true, exist: () => true };
-    const wrapped =
-      taskLib && taskLib.__esModule
-        ? taskLib
-        : { default: taskLib, ...taskLib };
+    const wrapped = taskLib && taskLib.__esModule ? taskLib : { default: taskLib, ...taskLib };
     return wrapped.default;
   })();
 
   assert.strictEqual(brokenTaskImport, undefined);
-  assert.throws(
-    () => brokenTaskImport.exist('/tmp/trivy-assurance.json'),
-    TypeError
-  );
+  assert.throws(() => brokenTaskImport.exist('/tmp/trivy-assurance.json'), TypeError);
 
   console.log('ok publishAssuranceResults uses task-lib without .default');
 }

--- a/trivy-task/trivyV2/scripts/publishAssuranceResults.test.js
+++ b/trivy-task/trivyV2/scripts/publishAssuranceResults.test.js
@@ -1,0 +1,116 @@
+const assert = require('assert');
+const fs = require('fs');
+const Module = require('module');
+const path = require('path');
+
+function loadPublishAssuranceResults(mockTask) {
+  const taskFlowPath = path.resolve(__dirname, '../dist/taskFlow.js');
+  const originalRequire = Module.prototype.require;
+
+  Module.prototype.require = function (id) {
+    if (id === 'azure-pipelines-task-lib/task') {
+      return mockTask;
+    }
+    return originalRequire.apply(this, arguments);
+  };
+
+  delete require.cache[taskFlowPath];
+  const { publishAssuranceResults } = require('../dist/taskFlow');
+
+  Module.prototype.require = originalRequire;
+  return publishAssuranceResults;
+}
+
+async function run() {
+  const taskFlowJs = fs.readFileSync(
+    path.resolve(__dirname, '../dist/taskFlow.js'),
+    'utf8'
+  );
+  assert.ok(
+    !taskFlowJs.includes(
+      "__importStar(require('azure-pipelines-task-lib/task'))).default"
+    ),
+    'compiled taskFlow must not read task-lib through .default'
+  );
+  assert.match(
+    taskFlowJs,
+    /require\(["']azure-pipelines-task-lib\/task["']\)/,
+    'compiled taskFlow must statically require task-lib'
+  );
+
+  const calls = { exist: [], addAttachment: [] };
+  const mockTask = {
+    exist: (filePath) => {
+      calls.exist.push(filePath);
+      return true;
+    },
+    addAttachment: (...args) => {
+      calls.addAttachment.push(args);
+    },
+  };
+
+  const publishAssuranceResults = loadPublishAssuranceResults(mockTask);
+
+  await publishAssuranceResults(
+    { hasAquaAccount: true },
+    '/tmp/trivy-assurance.json',
+    'trivy-assurance.json'
+  );
+
+  assert.deepStrictEqual(calls.exist, ['/tmp/trivy-assurance.json']);
+  assert.deepStrictEqual(calls.addAttachment, [
+    ['ASSURANCE_RESULT', 'trivy-assurance.json', '/tmp/trivy-assurance.json'],
+  ]);
+
+  calls.exist.length = 0;
+  calls.addAttachment.length = 0;
+
+  await publishAssuranceResults(
+    { hasAquaAccount: false },
+    '/tmp/trivy-assurance.json',
+    'trivy-assurance.json'
+  );
+
+  assert.deepStrictEqual(calls.exist, []);
+  assert.deepStrictEqual(calls.addAttachment, []);
+
+  calls.exist.length = 0;
+  calls.addAttachment.length = 0;
+
+  const publishWhenMissing = loadPublishAssuranceResults({
+    exist: () => false,
+    addAttachment: (...args) => {
+      calls.addAttachment.push(args);
+    },
+  });
+
+  await publishWhenMissing(
+    { hasAquaAccount: true },
+    '/tmp/missing-assurance.json',
+    'missing-assurance.json'
+  );
+
+  assert.deepStrictEqual(calls.addAttachment, []);
+
+  const brokenTaskImport = (() => {
+    const taskLib = { __esModule: true, exist: () => true };
+    const wrapped =
+      taskLib && taskLib.__esModule
+        ? taskLib
+        : { default: taskLib, ...taskLib };
+    return wrapped.default;
+  })();
+
+  assert.strictEqual(brokenTaskImport, undefined);
+  assert.throws(
+    () => brokenTaskImport.exist('/tmp/trivy-assurance.json'),
+    TypeError
+  );
+
+  console.log('ok publishAssuranceResults uses task-lib without .default');
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/trivy-task/trivyV2/taskFlow.ts
+++ b/trivy-task/trivyV2/taskFlow.ts
@@ -1,3 +1,4 @@
+import task = require('azure-pipelines-task-lib/task');
 import { TaskInputs } from './inputs';
 
 type FinalizeScanHandlers = {
@@ -41,8 +42,6 @@ export async function publishAssuranceResults(
   assuranceFilePath: string,
   assuranceFileName: string
 ) {
-  const task = (await import('azure-pipelines-task-lib/task')).default;
-
   if (inputs.hasAquaAccount && task.exist(assuranceFilePath)) {
     console.log('Publishing JSON assurance results...');
     task.addAttachment(


### PR DESCRIPTION
RCA: publishAssuranceResults accessed azure-pipelines-task-lib via
import().default, which is undefined for this CJS module shape, causing
task.exist() to throw after Aqua scans.

Change: switch to static require import (same as other v2 task files) and
add regression coverage for assurance publishing and compiled output.